### PR TITLE
Fixed OOM when importing large files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 tmp
 
 /testdata
+/dist
 
 # Log files
 log.json

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BINARY_darwin=$(BINDIR)/darwin/$(APPNAME)
 BINARY_windows=$(BINDIR)/win/$(APPNAME).exe
 BINARY_arm=$(BINDIR)/arm/$(APPNAME)
 
-TOOLS=./cmd/dbinspect ./cmd/dircheck ./cmd/exifprint
+TOOLS=./cmd/dbinspect ./cmd/dircheck ./cmd/exifprint ./cmd/qtdump
 
 PKG=./cmd/photos
 

--- a/cmd/photos/debug.go
+++ b/cmd/photos/debug.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/gorilla/mux"
+)
+
+type DebugHandler struct{}
+
+func (d DebugHandler) InitRoutes(router *mux.Router) {
+	// mux introspection
+	router.HandleFunc("/debug/mux", func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set("Context-Type", "text/html")
+		rw.WriteHeader(http.StatusOK)
+		fmt.Fprintln(rw, "<html><head><title>Endpoints</title></head><body>")
+		router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+			t, err := route.GetPathTemplate()
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(rw, fmt.Sprintf("<div><a href=\"%s\">%s</a></div>", t, t))
+			return nil
+		})
+		fmt.Fprintln(rw, "</body></html>")
+	}).Methods(("GET"))
+
+	// pprof routes
+	router.HandleFunc("/debug/pprof/", pprof.Index).Methods("GET")
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+
+	router.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	router.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	router.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	router.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+	router.Handle("/debug/pprof/block", pprof.Handler("block"))
+	router.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+}

--- a/domain/parallel_thumber.go
+++ b/domain/parallel_thumber.go
@@ -1,0 +1,57 @@
+package domain
+
+import (
+	"image"
+	"io"
+)
+
+type thumbRequest struct {
+	in io.Reader
+	f  Format
+	o  Orientation
+	s  ThumbSize
+
+	resp chan<- thumbResult
+}
+
+type thumbResult struct {
+	img image.Image
+	err error
+}
+
+type parallelThumber struct {
+	delegate Thumber
+
+	requests chan thumbRequest
+}
+
+func NewParallelThumber(delegate Thumber, n int) Thumber {
+	thumber := &parallelThumber{
+		delegate: delegate,
+		requests: make(chan thumbRequest),
+	}
+	for i := 0; i < n; i++ {
+		go thumber.loop()
+	}
+	return thumber
+}
+
+func (t *parallelThumber) CreateThumb(in io.Reader, f Format, o Orientation, size ThumbSize) (image.Image, error) {
+	res := make(chan thumbResult)
+	req := thumbRequest{in, f, o, size, res}
+
+	t.requests <- req
+	result := <-res
+	return result.img, result.err
+}
+
+func (t *parallelThumber) loop() {
+	for req := range t.requests {
+		req.resp <- t.makeThumb(req)
+	}
+}
+
+func (t *parallelThumber) makeThumb(r thumbRequest) thumbResult {
+	img, err := t.delegate.CreateThumb(r.in, r.f, r.o, r.s)
+	return thumbResult{img: img, err: err}
+}

--- a/geocoding/cache.go
+++ b/geocoding/cache.go
@@ -100,8 +100,10 @@ func (c *Cache) ReverseGeocode(ctx context.Context, lat, lon float64) (*gps.Addr
 	place, found, err := c.delegate.ReverseGeocode(ctx, lat, lon)
 	if found && place.BoundingBox != nil {
 		c.add(*place.BoundingBox, place)
-	} else {
+	} else if found {
 		log.Info("Place has no bounding box", zap.Stringer("place", place.ID))
+	} else {
+		log.Info("Place not found", zap.Float64("lat", lat), zap.Float64("long", lon))
 	}
 	return place, found, err
 }

--- a/library/loader.go
+++ b/library/loader.go
@@ -1,0 +1,93 @@
+package library
+
+import (
+	"encoding/base64"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/reusee/mmh3"
+)
+
+type Loader string
+
+func NewLoader(tmpDir string) Loader {
+	return Loader(tmpDir)
+}
+
+func (l Loader) LoadMediaObject(name string, in io.Reader) (MediaObject, error) {
+	h := mmh3.New128()
+	switch i := in.(type) {
+	case io.ReadSeeker:
+		// we can read the content and then reset the reader
+		if _, err := io.Copy(h, in); err != nil {
+			return nil, err
+		}
+		if _, err := i.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
+		return mediaReadSeeker{in: i, hash: BinaryHash(base64.StdEncoding.EncodeToString(h.Sum(nil)))}, nil
+	default:
+		// Canot seek in the stream, must temporarily store the content
+		staging := filepath.Join(string(l), name)
+		tmp, err := os.Create(staging)
+		if err != nil {
+			return nil, err
+		}
+		defer tmp.Close()
+		in = io.TeeReader(in, h)
+		if _, err := io.Copy(tmp, in); err != nil {
+			defer func() { os.Remove(staging) }()
+			return nil, err
+		}
+		return stagedMediaObject{path: staging, hash: BinaryHash(base64.StdEncoding.EncodeToString(h.Sum(nil)))}, nil
+	}
+
+}
+
+type ContentHandlerFunc func(io.Reader) error
+
+type MediaObject interface {
+	Hash() BinaryHash
+	Cleanup()
+	ProcessContent(ContentHandlerFunc) error
+}
+
+type mediaReadSeeker struct {
+	hash BinaryHash
+	in   io.Reader
+}
+
+func (m mediaReadSeeker) Hash() BinaryHash {
+	return m.hash
+}
+
+func (m mediaReadSeeker) Cleanup() {
+	// Nothing to do here
+}
+
+func (m mediaReadSeeker) ProcessContent(f ContentHandlerFunc) error {
+	return f(m.in)
+}
+
+type stagedMediaObject struct {
+	hash BinaryHash
+	path string
+}
+
+func (m stagedMediaObject) Hash() BinaryHash {
+	return m.hash
+}
+
+func (m stagedMediaObject) Cleanup() {
+	os.Remove(m.path)
+}
+
+func (m stagedMediaObject) ProcessContent(f ContentHandlerFunc) error {
+	in, err := os.Open(m.path)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	return f(in)
+}

--- a/library/loader_test.go
+++ b/library/loader_test.go
@@ -1,0 +1,133 @@
+package library
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadFromSeekableReader(t *testing.T) {
+	data := []struct {
+		Name string
+		Load func(in io.Reader) io.Reader
+		Dir  func(*testing.T, []fs.DirEntry)
+	}{
+		{
+			Name: "Reader is an *os.File",
+			Load: func(in io.Reader) io.Reader { return in },
+			Dir: func(t *testing.T, entries []fs.DirEntry) {
+				if len(entries) != 0 {
+					t.Errorf("Too many entries in temporary directory, should be empty. Found: %v", entries)
+				}
+			},
+		},
+		{
+			Name: "Reader is not seekable",
+			Load: func(in io.Reader) io.Reader { return wrappedReader{in} },
+			Dir: func(t *testing.T, entries []fs.DirEntry) {
+				if len(entries) != 1 {
+					t.Errorf("Too many entries in temporary directory, should contain only one. Found: %v", entries)
+				}
+				if entries[0].Name() != TestImageName {
+					t.Errorf("Bad file name in directory, expected XXx, got %s", entries[0].Name())
+				}
+			},
+		},
+	}
+	for i, d := range data {
+		t.Run(fmt.Sprintf("#%d %s", i, d.Name), func(t *testing.T) {
+			tmpdir, err := os.MkdirTemp("", "test-photoscope-*")
+			if err != nil {
+				t.Fatalf("Failed to initialize loader: %s", err)
+			}
+			defer func() { os.Remove(tmpdir) }()
+
+			// Verify that media objects are cleaned up after processing
+			defer func() {
+				assertFilesInDir(t, tmpdir, func(t *testing.T, de []fs.DirEntry) {
+					if len(de) != 0 {
+						t.Errorf("After cleaning up the media object, no files shall be left in tmp dir but there were: %v", de)
+					}
+				})
+			}()
+
+			loader := NewLoader(tmpdir)
+
+			// Load the expected photo content
+			in, expectedContent, err := loadTestPhoto(TestImageName)
+			if err != nil {
+				t.Fatalf("Failed to load test data: %s", err)
+			}
+			defer in.Close()
+
+			// Modify the reader as per the test
+			testedReader := d.Load(in)
+			media, err := loader.LoadMediaObject(TestImageName, testedReader)
+			if err != nil {
+				t.Fatalf("Loader failed to load file: %s", err)
+			}
+			defer media.Cleanup()
+
+			// Check contents of temporary directory
+			assertFilesInDir(t, tmpdir, d.Dir)
+
+			// Ensure processed media content is the same as of the loaded file
+			var actualContent []byte
+			if err := media.ProcessContent(func(r io.Reader) error {
+				actualContent, err = ioutil.ReadAll(r)
+				return err
+			}); err != nil {
+				t.Fatalf("Failed to process media object content: %s", err)
+			}
+			if c := bytes.Compare(expectedContent, actualContent); c != 0 {
+				t.Errorf("Content of media object does not match expected content (%d)", c)
+			}
+		})
+	}
+}
+
+func assertFilesInDir(t *testing.T, dir string, assertion func(*testing.T, []fs.DirEntry)) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("Failed to read temporary directory %s: %s", dir, err)
+		return
+	}
+	assertion(t, entries)
+}
+
+func loadTestPhoto(name string) (io.ReadCloser, []byte, error) {
+	basedir, err := os.Getwd()
+	if err != nil {
+		return nil, nil, err
+	}
+	path := filepath.Join(filepath.Clean(filepath.Join(basedir, "..")), "domain", "testdata", name)
+	in, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	content, err := ioutil.ReadAll(in)
+	if err != nil {
+		in.Close()
+		return in, nil, err
+	}
+	if _, err := in.Seek(0, io.SeekStart); err != nil {
+		in.Close()
+		return in, nil, err
+	}
+	return in, content, err
+}
+
+type wrappedReader struct {
+	r io.Reader
+}
+
+func (w wrappedReader) Read(p []byte) (n int, err error) {
+	return w.r.Read(p)
+}
+
+const TestImageName = "Canon_40D.jpg"

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -79,8 +79,8 @@ func init() {
 	cores = append(cores, zapcore.NewCore(jsonEncoder, zapcore.Lock(logfile), fileFilter))
 
 	// Loggly
-	loggly := NewLogglySink("e8e5b948-f0d9-4c99-ae02-09f17a48d7ac")
-	cores = append(cores, zapcore.NewCore(NewLogglyEncoder(), loggly, fileFilter))
+	// loggly := NewLogglySink("e8e5b948-f0d9-4c99-ae02-09f17a48d7ac")
+	// cores = append(cores, zapcore.NewCore(NewLogglyEncoder(), loggly, fileFilter))
 
 	rootLogger = zap.New(zapcore.NewTee(cores...))
 	rootLogger.With(zap.Bool("devmode", devmode)).Info("Logging initialized")


### PR DESCRIPTION
Instead of reading file content into memory, either read the original file directly or temporarily store the file in a temp dir when calculating its hash.